### PR TITLE
Hb/fix/date picker cutoff

### DIFF
--- a/src/pages/DateToUnix/index.vue
+++ b/src/pages/DateToUnix/index.vue
@@ -44,7 +44,7 @@ const getFormatteddates = (date) => {
             <PageHeader />
         </div>
         <div class="grid mt-1">
-            <div class="block card block1">
+            <div class="block card block1 overflow-inherit">
                 <div class="p-3">
                     <div class="p-2">
                         <p class="muted">Choose a date and time from the datepicker</p>

--- a/src/pages/DateToUnix/style.css
+++ b/src/pages/DateToUnix/style.css
@@ -1,0 +1,3 @@
+.overflow-inherit {
+  overflow: inherit;
+}

--- a/src/pages/TimeZoneConverter/index.vue
+++ b/src/pages/TimeZoneConverter/index.vue
@@ -47,7 +47,7 @@ const handleSelectChange = () => {
             <PageHeader />
         </div>
         <div class="grid mt-1">
-            <div class="block card block1">
+            <div class="block card block1 overflow-inherit">
                 <div class="p-3">
                     <div class="d-flex flex-column gap-2">
                         <div class="mt-2 text-muted"><strong>Select date and time </strong></div>

--- a/src/pages/TimeZoneConverter/style.css
+++ b/src/pages/TimeZoneConverter/style.css
@@ -1,0 +1,3 @@
+.overflow-inherit {
+  overflow: inherit;
+}


### PR DESCRIPTION
### Fixes #118  Date Picker cut off 
#### Changes done-

- [x] Added `overflow: inherit` style to parent div in date to Unix convertor
- [x] Added `overflow: inherit` style to parent div in Timezone converter

#### Screenshots-
Date to Unix converter-
![image](https://github.com/techrail/devta/assets/56753150/7aad9403-6df2-46a2-827b-0f91591d5e8a)

Timezone converter-
![image](https://github.com/techrail/devta/assets/56753150/05f5da31-fac2-4c9a-87c9-0ba04a6edc63)
