### PR TITLE
added `id` prop to copy components and adds a `jsconfig.json` 

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/components/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@stores/*": ["./src/stores/*"],
+      "@src/*": ["./src/*"]
+    }
+  }
+}


### PR DESCRIPTION
fixes #134 
- user can provide `id` prop to set the id on the components
- added fallback. 
	- if a user does not provide a ID, the title will be used as ID instead
	- this ensure existing component and pages does not break and we can gradually add id prop to the components
 
- also adds a `jsconfig.json` to add auto-completion in vscode when using `@